### PR TITLE
Add basic Ollama image generator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repo provides the scaffold and features needed to generate images right ins
 ## 🧰 Features
 
 - 🖼 Generate images from text prompts directly inside Obsidian
+- 🤖 Powered by [Ollama](https://ollama.ai/) for local AI image generation
 - ⚙️ VaultOS-ready modular structure (`src/`, `ops/`, `config/`, `dist/`)
 - 📦 Rollup build system with `manifest.json`
 - 📁 Ready-to-use GitHub Actions and PR templates
@@ -40,6 +41,8 @@ npm run build
 ```
 
 After building, copy the contents of `/dist` into your Obsidian vault’s `.obsidian/plugins/` folder.
+
+The plugin uses Ollama locally. You can configure the model and output folder from the plugin settings inside Obsidian.
 
 ---
 

--- a/change-log.md
+++ b/change-log.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-- Documentation updated for image generation plugin
+- Add Ollama-powered image generator plugin skeleton
 
 ## [0.1.0] - YYYY-MM-DD
 

--- a/config/default.ts
+++ b/config/default.ts
@@ -1,0 +1,9 @@
+export interface PluginSettings {
+  model: string;
+  outputDir: string;
+}
+
+export const DEFAULT_SETTINGS: PluginSettings = {
+  model: 'stable-diffusion',
+  outputDir: 'OllamaImages'
+};

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,11 @@
+{
+  "id": "vault-image-generator",
+  "name": "Vault Image Generator",
+  "version": "0.1.0",
+  "minAppVersion": "0.15.0",
+  "description": "Generate images from prompts using Ollama",
+  "author": "PtiCalin",
+  "authorUrl": "https://github.com/your-username",
+  "main": "dist/main.js",
+  "isDesktopOnly": true
+}

--- a/ops/ollama.ts
+++ b/ops/ollama.ts
@@ -1,0 +1,8 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export async function runOllama(model: string, prompt: string, output: string): Promise<void> {
+  await execFileAsync('ollama', ['run', model, prompt, '--image', output]);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "vault-image-generator",
+  "version": "0.1.0",
+  "description": "Ollama powered image generator for Obsidian",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -watch -p tsconfig.json"
+  },
+  "devDependencies": {
+    "obsidian": "^1.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "ollama": "*"
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,92 @@
+import { App, Plugin, PluginSettingTab, Setting, Notice, MarkdownView, normalizePath } from 'obsidian';
+import { DEFAULT_SETTINGS, PluginSettings } from '../config/default';
+import { runOllama } from '../ops/ollama';
+import * as fs from 'fs/promises';
+
+export default class VaultImageGenerator extends Plugin {
+  settings: PluginSettings;
+
+  async onload() {
+    await this.loadSettings();
+
+    this.addCommand({
+      id: 'generate-image-with-ollama',
+      name: 'Generate Image with Ollama',
+      callback: () => this.generateFromSelection(),
+    });
+
+    this.addSettingTab(new ImageGeneratorSettingTab(this.app, this));
+  }
+
+  onunload() {}
+
+  async generateFromSelection() {
+    const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+    if (!view) {
+      new Notice('No active markdown view');
+      return;
+    }
+    const editor = view.editor;
+    const prompt = editor.getSelection() || editor.getLine(editor.getCursor().line);
+
+    const dir = normalizePath(this.settings.outputDir);
+    await fs.mkdir(dir, { recursive: true });
+    const filePath = normalizePath(`${dir}/${Date.now()}.png`);
+
+    try {
+      await runOllama(this.settings.model, prompt, filePath);
+      const data = await fs.readFile(filePath);
+      await this.app.vault.createBinary(filePath, data);
+      new Notice(`Image saved to ${filePath}`);
+    } catch (err) {
+      console.error(err);
+      new Notice('Failed to generate image');
+    }
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
+}
+
+class ImageGeneratorSettingTab extends PluginSettingTab {
+  plugin: VaultImageGenerator;
+
+  constructor(app: App, plugin: VaultImageGenerator) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display() {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName('Ollama model')
+      .setDesc('Model to use for image generation')
+      .addText(text =>
+        text
+          .setPlaceholder('stable-diffusion')
+          .setValue(this.plugin.settings.model)
+          .onChange(async (value) => {
+            this.plugin.settings.model = value;
+            await this.plugin.saveSettings();
+          }));
+
+    new Setting(containerEl)
+      .setName('Output folder')
+      .setDesc('Folder to store generated images')
+      .addText(text =>
+        text
+          .setPlaceholder('OllamaImages')
+          .setValue(this.plugin.settings.outputDir)
+          .onChange(async (value) => {
+            this.plugin.settings.outputDir = value;
+            await this.plugin.saveSettings();
+          }));
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "lib": ["es6"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "ops/**/*", "config/**/*"]
+}


### PR DESCRIPTION
## Summary
- add initial TypeScript plugin scaffold
- define plugin settings for Ollama model and output folder
- document Ollama support in README
- update changelog

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684222fd71c8832288ed1d0ffac50d05