### PR TITLE
Add Rollup build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,17 @@ cd vault_image-generator
 
 ### 🛠 Local Setup
 
+Install dependencies and bundle the plugin:
+
 ```bash
 npm install
 npm run build
+```
+
+During development you can watch the files and rebuild on changes with:
+
+```bash
+npm run dev
 ```
 
 After building, copy the contents of `/dist` into your Obsidian vault’s `.obsidian/plugins/` folder.

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.1.0",
   "description": "Ollama powered image generator for Obsidian",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "dev": "tsc -watch -p tsconfig.json"
+    "build": "rollup -c",
+    "dev": "rollup -c -w"
   },
   "devDependencies": {
     "obsidian": "^1.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "rollup": "^3.0.0",
+    "@rollup/plugin-typescript": "^11.0.0"
   },
   "dependencies": {
     "ollama": "*"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,19 @@
+import typescript from '@rollup/plugin-typescript';
+import { builtinModules } from 'module';
+
+export default {
+  input: 'src/main.ts',
+  output: {
+    file: 'dist/main.js',
+    format: 'cjs',
+    sourcemap: false,
+  },
+  external: [
+    'obsidian',
+    ...builtinModules,
+    ...builtinModules.map(m => `node:${m}`)
+  ],
+  plugins: [
+    typescript({ tsconfig: './tsconfig.json' })
+  ],
+};


### PR DESCRIPTION
## Summary
- add `rollup.config.js` bundling TypeScript source
- use Rollup in npm scripts and add dev dependencies
- document the Rollup build process in the README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: rollup: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bc444714832293e97b6d5bf3dcf5