### PR TITLE
Add setup script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ git clone https://github.com/PtiCalin/vault_image-generator.git
 cd vault_image-generator
 ```
 
+For an automated setup you can simply run:
+
+```bash
+./setup.sh
+```
+
 ### 🛠 Local Setup
 
 Install dependencies and bundle the plugin:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm install
+npm run build


### PR DESCRIPTION
## Summary
- add a simple `setup.sh` for installing dependencies and building the plugin
- document the automated setup option in the Getting Started section of the README

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d6c7fd2c8322a7cc330b84930742