### PR TITLE
Add file header comments

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -1,3 +1,8 @@
+// === config/default.ts ===
+// Purpose: Define default configuration values and the PluginSettings interface.
+// Dependencies: none.
+// Output: Exports PluginSettings and DEFAULT_SETTINGS constants.
+// Example: DEFAULT_SETTINGS.model is "stable-diffusion".
 export interface PluginSettings {
   model: string;
   outputDir: string;

--- a/ops/ollama.ts
+++ b/ops/ollama.ts
@@ -1,3 +1,8 @@
+// === ops/ollama.ts ===
+// Purpose: Execute the `ollama` CLI to create an image from a text prompt.
+// Dependencies: child_process execFile and util.promisify.
+// Output: Resolves once the image file specified by the caller has been written.
+// Example: await runOllama("stable-diffusion", "A fox in the woods", "./fox.png");
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,8 @@
+// === src/main.ts ===
+// Purpose: Obsidian plugin that sends text selections to Ollama and saves the resulting image.
+// Dependencies: Obsidian API, fs/promises, config/default.ts, ops/ollama.ts.
+// Output: Creates an image file in the configured output folder of the vault.
+// Example: Select text, run "Generate Image with Ollama", then check the output directory for the new image.
 import { App, Plugin, PluginSettingTab, Setting, Notice, MarkdownView, normalizePath } from 'obsidian';
 import { DEFAULT_SETTINGS, PluginSettings } from '../config/default';
 import { runOllama } from '../ops/ollama';


### PR DESCRIPTION
## Summary
- document plugin's purpose and usage in `src/main.ts`
- add header docs in `ops/ollama.ts`
- document default configuration in `config/default.ts`

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e82262d883229415c6ebf0749ca0